### PR TITLE
test: Add Jest snapshot

### DIFF
--- a/components/__tests__/Message.js
+++ b/components/__tests__/Message.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+
+import Message from '../Message';
+
+describe('Message component', () => {
+  it('should render without issues', () => {
+    const component = create(<Message />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/components/__tests__/__snapshots__/Message.js.snap
+++ b/components/__tests__/__snapshots__/Message.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Message component should render without issues 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "flex-start",
+      "paddingHorizontal": 10,
+      "width": 650,
+    }
+  }
+>
+  <Image
+    style={
+      Object {
+        "borderRadius": 30,
+        "height": 60,
+        "marginRight": 20,
+        "marginVertical": 15,
+        "width": 60,
+      }
+    }
+  />
+  <View>
+    <Text />
+    <Text
+      style={
+        Object {
+          "color": "#757E90",
+          "fontSize": 12,
+          "paddingTop": 5,
+        }
+      }
+    />
+  </View>
+</View>
+`;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
 		"react-test-renderer": "16.6.3"
 	},
 	"jest": {
-		"preset": "react-native"
+		"preset": "react-native",
+    "transform": {
+      "node_modules/react-native/.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
+    }
 	},
 	"rnpm": {
 		"assets": [

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
 	},
 	"jest": {
 		"preset": "react-native",
-    "transform": {
-      "node_modules/react-native/.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
-    }
+		"transform": {
+			"node_modules/react-native/.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
+		}
 	},
 	"rnpm": {
 		"assets": [


### PR DESCRIPTION
In this PR:

- Add `transform` property so it can run `npm test` without any error
- Add snapshot test for Message component